### PR TITLE
UITestCase.h: Remove #import "Reachability.h"

### DIFF
--- a/ADFiOSReferenceAppUITests/BaseTestCases/UITestCase.h
+++ b/ADFiOSReferenceAppUITests/BaseTestCases/UITestCase.h
@@ -15,7 +15,6 @@
 
 #import <XCTest/XCTest.h>
 #import "XCUIElement+DelayTaps.h"
-#import "Reachability.h"
 #import <SystemConfiguration/SystemConfiguration.h>
 
 


### PR DESCRIPTION
*Issue #, if available:*
#2 

*Description of changes:*

- Remove unused `#import "Reachability.h"`
- This also fixes Reachability not found problem #2 

I've tested in my environment: Xcode Version 10.2 (10E125),
and confirmed to passed all tests fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
