### PR TITLE
Fixed documentation urls

### DIFF
--- a/ADFiOSReferenceApp/WebViewController.m
+++ b/ADFiOSReferenceApp/WebViewController.m
@@ -24,7 +24,7 @@
 @property NSURL *URL;
 @end
 
-static NSString* const DEFAULT_URL = @"https://aws.amazon.com/documentation/devicefarm/";
+static NSString* const DEFAULT_URL = @"https://docs.aws.amazon.com/devicefarm";
 static NSString* const ERROR_MESSAGE_FORMAT = @"\"%@\" is a malformed URL. Please enter a URL in the correct format. An example would be %@";
 @implementation WebViewController
 

--- a/ADFiOSReferenceAppUITests/CustomWebTest.m
+++ b/ADFiOSReferenceAppUITests/CustomWebTest.m
@@ -18,7 +18,7 @@
 static NSString * const HTTP_TAB_ID = @"HTTP";
 static NSString * const NAVIGATION_BAR_ID = @"navigation bar";
 static NSString * const GO_BUTTON_ID = @"Go";
-static NSString * const URL = @"https://aws.amazon.com/documentation/devicefarm/";
+static NSString * const URL = @"https://docs.aws.amazon.com/devicefarm";
 static NSString * const DEVELOPER_GUIDE_LINK_ID = @"Developer Guide";
 static NSString * const EXISTS_PREDICATE = @"exists==1";
 static NSTimeInterval const TAP_DELAY = 1;


### PR DESCRIPTION
*Description of changes:*

The URL of Device Farm docs has changed

```
$ curl -i https://aws.amazon.com/documentation/devicefarm/
HTTP/2 301
...
location: https://docs.aws.amazon.com/devicefarm/index.html
date: Thu, 23 May 2019 15:39:01 GMT
...
```

This PR replace with new URL

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
